### PR TITLE
[Reviewer: Ellie] Initialize the cond var to use CLOCK_MONOTONIC

### DIFF
--- a/include/eventq.h
+++ b/include/eventq.h
@@ -58,8 +58,12 @@ public:
     _terminated(false)
   {
     pthread_mutex_init(&_m, NULL);
-    pthread_cond_init(&_w_cond, NULL);
-    pthread_cond_init(&_r_cond, NULL);
+    pthread_condattr_t cond_attr;
+    pthread_condattr_init(&cond_attr);
+    pthread_condattr_setclock(&cond_attr, CLOCK_MONOTONIC);
+    pthread_cond_init(&_w_cond, &cond_attr);
+    pthread_cond_init(&_r_cond, &cond_attr);
+    pthread_condattr_destroy(&cond_attr);
   };
 
   ~eventq()


### PR DESCRIPTION
Ellie,

Please can you review my fix to initialize the cond var to use CLOCK_MONOTONIC - as it is, pop() calls always return immediately (because CLOCK_MONOTONIC times are always less than CLOCK_REALTIME).

Without this, on failure, we tight-loop if the SAS is unavailable.

Thanks,

Matt
