### PR TITLE
[Reviewer: Jim] Initialize the cond var to use CLOCK_MONOTONIC

### DIFF
--- a/include/eventq.h
+++ b/include/eventq.h
@@ -58,8 +58,12 @@ public:
     _terminated(false)
   {
     pthread_mutex_init(&_m, NULL);
-    pthread_cond_init(&_w_cond, NULL);
-    pthread_cond_init(&_r_cond, NULL);
+    pthread_condattr_t cond_attr;
+    pthread_condattr_init(&cond_attr);
+    pthread_condattr_setclock(&cond_attr, CLOCK_MONOTONIC);
+    pthread_cond_init(&_w_cond, &cond_attr);
+    pthread_cond_init(&_r_cond, &cond_attr);
+    pthread_condattr_destroy(&cond_attr);
   };
 
   ~eventq()


### PR DESCRIPTION
Jim,

Please can you review my fix to initialize the cond var to use CLOCK_MONOTONIC - as it is, pop() calls always return immediately (because CLOCK_MONOTONIC times are always less than CLOCK_REALTIME).  Without this, on failure, we tight-loop if the SAS is unavailable.

This has already been reviewed by Ellie, but I believe you own this repo so wanted to give you an opportunity to object.  I've live-tested but not UT-ed (as I don't think there is currently any infrastructure for this).

Thanks,

Matt
