### PR TITLE
[Reviewer: Ellie][From: Alex] Add debug symbols to SAS client library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ libsas.a: sas.o
 	ar cr libsas.a sas.o
 
 sas.o: source/sas.cpp include/sas.h include/eventq.h include/config.h
-	g++ -Iinclude -std=c++0x -c source/sas.cpp -Wall -Werror
+	g++ -Iinclude -std=c++0x -c source/sas.cpp -Wall -Werror -ggdb3
 
 include/config.h: configure
 	./configure
@@ -22,5 +22,5 @@ test: sas_test
 	./sas_test
 
 sas_test: libsas.a source/ut/sastestutil.h source/ut/main.cpp
-	g++ source/ut/main.cpp -o sas_test -I include -std=c++0x -L. -lsas -lrt -Wall -Werror
+	g++ source/ut/main.cpp -o sas_test -I include -std=c++0x -L. -lsas -lrt -Wall -Werror -ggdb3
 


### PR DESCRIPTION
Ellie please can you review this trivial change to add debugging symbols to the SAS client library. I need these to debug a crash I'm seeing in ralf load tests. 
