### PR TITLE
add MVD_MOVABLE_BLOCK Marker Constant

### DIFF
--- a/include/sas.h
+++ b/include/sas.h
@@ -76,6 +76,7 @@ static const int MARKER_ID_END = 0x01000004;
 static const int MARKER_ID_DIALED_DIGITS = 0x01000005;
 static const int MARKER_ID_CALLING_DN = 0x01000006;
 static const int MARKER_ID_CALLED_DN = 0x01000007;
+static const int MARKER_ID_MVD_MOVABLE_BLOCK = 0x01000015;
 static const int MARKED_ID_GENERIC_CORRELATOR = 0x01000016;
 static const int MARKED_ID_FLUSH = 0x01000017;
 


### PR DESCRIPTION
add a constant to the marker list to facilitate movable block code for geographic redundancy