### PR TITLE
Reviewer Jim - Include unistd.h to compile on g++ version 4.7+

### DIFF
--- a/source/sas.cpp
+++ b/source/sas.cpp
@@ -41,6 +41,7 @@
 #include <netdb.h>
 #include <stdarg.h>
 #include <sys/socket.h>
+#include <unistd.h>
 
 #include "sas.h"
 #include "sas_eventq.h"


### PR DESCRIPTION
Attempts to build on various `g++` versions:

```
ubuntu@ip-10-48-154-121:~/src/sprout/modules/sas-client$ sudo update-alternatives --set gcc /usr/bin/gcc-4.4
update-alternatives: using /usr/bin/gcc-4.4 to provide /usr/bin/gcc (gcc) in manual mode.
ubuntu@ip-10-48-154-121:~/src/sprout/modules/sas-client$ make -B
./configure
checking for atomic... no
checking for cstdatomic... yes
g++ -Iinclude -std=c++0x -c source/sas.cpp -Wall -Werror -ggdb3
ar cr libsas.a sas.o
ubuntu@ip-10-48-154-121:~/src/sprout/modules/sas-client$ sudo update-alternatives --set gcc /usr/bin/gcc-4.5
update-alternatives: using /usr/bin/gcc-4.5 to provide /usr/bin/gcc (gcc) in manual mode.
ubuntu@ip-10-48-154-121:~/src/sprout/modules/sas-client$ make -B
./configure
checking for atomic... yes
checking for cstdatomic... no
g++ -Iinclude -std=c++0x -c source/sas.cpp -Wall -Werror -ggdb3
ar cr libsas.a sas.o
ubuntu@ip-10-48-154-121:~/src/sprout/modules/sas-client$ sudo update-alternatives --set gcc /usr/bin/gcc-4.6
update-alternatives: using /usr/bin/gcc-4.6 to provide /usr/bin/gcc (gcc) in manual mode.
ubuntu@ip-10-48-154-121:~/src/sprout/modules/sas-client$ make -B
./configure
checking for atomic... yes
checking for cstdatomic... no
g++ -Iinclude -std=c++0x -c source/sas.cpp -Wall -Werror -ggdb3
ar cr libsas.a sas.o
ubuntu@ip-10-48-154-121:~/src/sprout/modules/sas-client$ sudo update-alternatives --set gcc /usr/bin/gcc-4.7
update-alternatives: using /usr/bin/gcc-4.7 to provide /usr/bin/gcc (gcc) in manual mode.
ubuntu@ip-10-48-154-121:~/src/sprout/modules/sas-client$ make -B
./configure
checking for atomic... yes
checking for cstdatomic... no
g++ -Iinclude -std=c++0x -c source/sas.cpp -Wall -Werror -ggdb3
source/sas.cpp: In member function ‘void SAS::Connection::writer()’:
source/sas.cpp:299:13: error: ‘::close’ has not been declared
source/sas.cpp:307:7: error: ‘::close’ has not been declared
source/sas.cpp: In member function ‘bool SAS::Connection::connect_init()’:
source/sas.cpp:380:7: error: ‘::close’ has not been declared
source/sas.cpp:391:7: error: ‘::close’ has not been declared
source/sas.cpp:446:5: error: ‘::close’ has not been declared
make: *** [sas.o] Error 1
ubuntu@ip-10-48-154-121:~/src/sprout/modules/sas-client$ sudo update-alternatives --set gcc /usr/bin/gcc-4.8
update-alternatives: using /usr/bin/gcc-4.8 to provide /usr/bin/gcc (gcc) in manual mode.
ubuntu@ip-10-48-154-121:~/src/sprout/modules/sas-client$ make -B
./configure
checking for atomic... yes
checking for cstdatomic... no
g++ -Iinclude -std=c++0x -c source/sas.cpp -Wall -Werror -ggdb3
source/sas.cpp: In member function ‘void SAS::Connection::writer()’:
source/sas.cpp:299:13: error: ‘::close’ has not been declared
             ::close(_sock);
             ^
source/sas.cpp:307:7: error: ‘::close’ has not been declared
       ::close(_sock);
       ^
source/sas.cpp: In member function ‘bool SAS::Connection::connect_init()’:
source/sas.cpp:380:7: error: ‘::close’ has not been declared
       ::close(_sock);
       ^
source/sas.cpp:391:7: error: ‘::close’ has not been declared
       ::close(_sock);
       ^
source/sas.cpp:446:5: error: ‘::close’ has not been declared
     ::close(_sock);
     ^
make: *** [sas.o] Error 1
```

The fix is to include `unistd.h` explicitly before using `::close()`.  New builds:

```
ubuntu@ip-10-48-154-121:~/src/sprout/modules/sas-client$ sudo update-alternatives --set gcc /usr/bin/gcc-4.4
update-alternatives: using /usr/bin/gcc-4.4 to provide /usr/bin/gcc (gcc) in manual mode.
ubuntu@ip-10-48-154-121:~/src/sprout/modules/sas-client$ make -B
./configure
checking for atomic... no
checking for cstdatomic... yes
g++ -Iinclude -std=c++0x -c source/sas.cpp -Wall -Werror -ggdb3
ar cr libsas.a sas.o
ubuntu@ip-10-48-154-121:~/src/sprout/modules/sas-client$ sudo update-alternatives --set gcc /usr/bin/gcc-4.5
update-alternatives: using /usr/bin/gcc-4.5 to provide /usr/bin/gcc (gcc) in manual mode.
ubuntu@ip-10-48-154-121:~/src/sprout/modules/sas-client$ make -B
./configure
checking for atomic... yes
checking for cstdatomic... no
g++ -Iinclude -std=c++0x -c source/sas.cpp -Wall -Werror -ggdb3
ar cr libsas.a sas.o
ubuntu@ip-10-48-154-121:~/src/sprout/modules/sas-client$ sudo update-alternatives --set gcc /usr/bin/gcc-4.6
update-alternatives: using /usr/bin/gcc-4.6 to provide /usr/bin/gcc (gcc) in manual mode.
ubuntu@ip-10-48-154-121:~/src/sprout/modules/sas-client$ make -B
./configure
checking for atomic... yes
checking for cstdatomic... no
g++ -Iinclude -std=c++0x -c source/sas.cpp -Wall -Werror -ggdb3
ar cr libsas.a sas.o
ubuntu@ip-10-48-154-121:~/src/sprout/modules/sas-client$ sudo update-alternatives --set gcc /usr/bin/gcc-4.7
update-alternatives: using /usr/bin/gcc-4.7 to provide /usr/bin/gcc (gcc) in manual mode.
ubuntu@ip-10-48-154-121:~/src/sprout/modules/sas-client$ make -B
./configure
checking for atomic... yes
checking for cstdatomic... no
g++ -Iinclude -std=c++0x -c source/sas.cpp -Wall -Werror -ggdb3
ar cr libsas.a sas.o
ubuntu@ip-10-48-154-121:~/src/sprout/modules/sas-client$ sudo update-alternatives --set gcc /usr/bin/gcc-4.8
update-alternatives: using /usr/bin/gcc-4.8 to provide /usr/bin/gcc (gcc) in manual mode.
ubuntu@ip-10-48-154-121:~/src/sprout/modules/sas-client$ make -B
./configure
checking for atomic... yes
checking for cstdatomic... no
g++ -Iinclude -std=c++0x -c source/sas.cpp -Wall -Werror -ggdb3
ar cr libsas.a sas.o
```
