### PR TITLE
Remove virtual methods from Message to prevent clearwater UT breakages

### DIFF
--- a/include/sas.h
+++ b/include/sas.h
@@ -221,7 +221,6 @@ public:
   protected:
     size_t params_buf_len() const;
     void write_params(std::string& s) const;
-    virtual Timestamp get_timestamp() const;
 
   private:
     TrailId _trail;
@@ -279,6 +278,8 @@ public:
       Branch = 1,
       Trace = 2
     };
+
+    Timestamp get_timestamp() const;
 
     std::string to_string(Scope scope, bool reactivate) const;
   };

--- a/source/sas.cpp
+++ b/source/sas.cpp
@@ -550,13 +550,6 @@ void SAS::Message::write_params(std::string& s) const
 }
 
 
-// Get the timestamp to be used on the message.
-SAS::Timestamp SAS::Message::get_timestamp() const
-{
-  return SAS::get_current_timestamp();
-}
-
-
 std::string SAS::Event::to_string() const
 {
   size_t len = EVENT_HDR_SIZE + params_buf_len();
@@ -619,6 +612,13 @@ std::string SAS::Marker::to_string(Marker::Scope scope, bool reactivate) const
   write_params(s);
 
   return std::move(s);
+}
+
+
+// Get the timestamp to be used on the message.
+SAS::Timestamp SAS::Marker::get_timestamp() const
+{
+  return SAS::get_current_timestamp();
 }
 
 


### PR DESCRIPTION
Making `get_timestamp` a virtual method on the Message class has broken linking in some Clearwater unit tests. This PR changes this so that instead of a virtual method on Message and a non-virtual one on Event, we have non-virtual methods on both Event and Marker. 
