### PR TITLE
Prevent shutdown from taking ages when SAS is unresponsive/misconfigured

### DIFF
--- a/source/sas.cpp
+++ b/source/sas.cpp
@@ -83,6 +83,7 @@ private:
   std::string _sas_address;
 
   SASeventq<std::string> _msg_q;
+  bool _connected;
 
   pthread_t _writer;
 
@@ -90,7 +91,7 @@ private:
   int _sock;
 
   /// Send timeout for the socket in seconds.
-  static const int SEND_TIMEOUT = 30;
+  static const int SEND_TIMEOUT = 5;
 
   /// Maximum depth of SAS message queue.
   static const int MAX_MSG_QUEUE = 1000;
@@ -201,6 +202,16 @@ SAS::Connection::~Connection()
     // Signal the writer thread to disconnect the socket and end.
     _msg_q.terminate();
 
+    // If we haven't yet connected, we can cancel the thread - there's
+    // no risk of truncating data mid-write. This prevents termination
+    // from taking an unnecessarily long time when SAS is unreachable
+    // (which would happen if we didn't cancel the thread and instead
+    // waited for connect() to time out).
+    if (!_connected)
+    {
+      pthread_cancel(_writer);
+    }
+
     // Wait for the writer thread to exit.
     pthread_join(_writer, NULL);
 
@@ -221,9 +232,10 @@ void SAS::Connection::writer()
   while (true)
   {
     int reconnect_timeout = 10000;  // If connect fails, retry every 10 seconds.
-
+    _connected = false;
     if (connect_init())
     {
+      _connected = true;
       // Now can start dequeuing and sending data.
       std::string msg;
       while ((_sock != -1) && (_msg_q.pop(msg)))


### PR DESCRIPTION
This fixes https://github.com/Metaswitch/sas-client/issues/37. There are two parts to it:
* reducing SEND_TIMEOUT from 30s to 5s, as agreed with @benritchie 
* if SAS::term() is called before we're successfully connected (and so we don't need to worry about truncating the data we're sending), call pthread_cancel on the writer thread to get it to exit immediately (connect() is a cancel point). This is an even faster solution to the case I think we're most likely to hit.

I've tested by configuring a Project Clearwater Homestead node with '1.2.3.4' as its SAS, stopping the Homestead process, and confirming that it exits near-immediately instead of taking several seconds while connect() times out, as happens without this fix.