### PR TITLE
Add support for the trail association method

### DIFF
--- a/include/sas.h
+++ b/include/sas.h
@@ -324,6 +324,9 @@ public:
   static void report_marker(const Marker& marker,
                             Marker::Scope scope = Marker::Scope::None,
                             bool reactivate = true);
+  static void associate_trails(TrailId trail_a,
+                               TrailId trail_b,
+                               Marker::Scope scope = Marker::Scope::Branch);
 
   static Timestamp get_current_timestamp();
 

--- a/source/sas.cpp
+++ b/source/sas.cpp
@@ -459,6 +459,21 @@ void SAS::report_marker(const Marker& marker, Marker::Scope scope, bool reactiva
   }
 }
 
+void SAS::associate_trails(TrailId trail_a,
+                           TrailId trail_b,
+                           Marker::Scope scope)
+{
+  std::string trail_assoc_msg;
+  write_hdr(trail_assoc_msg, 29, SAS_MSG_TRAIL_ASSOC, get_current_timestamp());
+  write_trail(trail_assoc_msg, trail_a);
+  write_trail(trail_assoc_msg, trail_b);
+  write_int8(trail_assoc_msg, (uint8_t)scope);
+  if (_connection)
+  {
+    _connection->send_msg(trail_assoc_msg);
+  }
+}
+
 
 SAS::Timestamp SAS::get_current_timestamp()
 {

--- a/source/sas_internal.h
+++ b/source/sas_internal.h
@@ -49,6 +49,7 @@
 
 // SAS message types.
 const int SAS_MSG_INIT   = 1;
+const int SAS_MSG_TRAIL_ASSOC   = 2;
 const int SAS_MSG_EVENT  = 3;
 const int SAS_MSG_MARKER = 4;
 


### PR DESCRIPTION
This pull request adds a SAS::associate_trails method for direct trail association. I've tested live by applying this to the "clearwater" branch, using associate_trails in Clearwater to associate two dialogs, and checking that the trails are combined in SAS (where they weren't previously).