### PR TITLE
Send heartbeat messages once a second

### DIFF
--- a/include/sas.h
+++ b/include/sas.h
@@ -343,6 +343,8 @@ private:
   static void write_data(std::string& s, size_t length, const char* data);
   static void write_timestamp(std::string& s);
   static void write_trail(std::string& s, TrailId trail);
+  
+  static std::string heartbeat_msg();
 
   static std::atomic<TrailId> _next_trail_id;
   class Connection;


### PR DESCRIPTION
Fixes https://github.com/Metaswitch/sas-client/issues/20.

I've tested live, verifying:
* that the messages are sent once a second if there's no other traffic
* that Wireshark recognises them as SAS heartbeats
* that heartbeats aren't sent if other traffic is flowing to keep the connection alive