### PR TITLE
align marker constants and add primary device aka subscriber number

### DIFF
--- a/include/sas.h
+++ b/include/sas.h
@@ -70,30 +70,34 @@
 #define SAS_CLIENT_VERSION = "1.0.0"
 
 // Marker IDs
-static const int MARKER_ID_PROTOCOL_ERROR = 0x01000001;
-static const int MARKER_ID_START = 0x01000003;
-static const int MARKER_ID_END = 0x01000004;
-static const int MARKER_ID_DIALED_DIGITS = 0x01000005;
-static const int MARKER_ID_CALLING_DN = 0x01000006;
-static const int MARKER_ID_CALLED_DN = 0x01000007;
-static const int MARKER_ID_MVD_MOVABLE_BLOCK = 0x01000015;
-static const int MARKED_ID_GENERIC_CORRELATOR = 0x01000016;
-static const int MARKED_ID_FLUSH = 0x01000017;
+static const int MARKER_ID_PROTOCOL_ERROR       = 0x01000001;
+static const int MARKER_ID_START                = 0x01000003;
+static const int MARKER_ID_END                  = 0x01000004;
+static const int MARKER_ID_DIALED_DIGITS        = 0x01000005;
+static const int MARKER_ID_CALLING_DN           = 0x01000006;
+static const int MARKER_ID_CALLED_DN            = 0x01000007;
 
-static const int MARKER_ID_SIP_REGISTRATION = 0x010B0004;
-static const int MARKER_ID_SIP_ALL_REGISTER = 0x010B0005;
+// Sometimes referred to as "subscriber number"
+static const int MARKER_ID_PRIMARY_DEVICE       = 0x01000008;
+
+static const int MARKER_ID_MVD_MOVABLE_BLOCK    = 0x01000015;
+static const int MARKED_ID_GENERIC_CORRELATOR   = 0x01000016;
+static const int MARKED_ID_FLUSH                = 0x01000017;
+
+static const int MARKER_ID_SIP_REGISTRATION     = 0x010B0004;
+static const int MARKER_ID_SIP_ALL_REGISTER     = 0x010B0005;
 static const int MARKER_ID_SIP_SUBSCRIBE_NOTIFY = 0x010B0006;
-static const int MARKER_ID_SIP_CALL_ID = 0x010C0001;
-static const int MARKER_ID_IMS_CHARGING_ID = 0x010C0002;
-static const int MARKER_ID_VIA_BRANCH_PARAM = 0x010C0003;
+static const int MARKER_ID_SIP_CALL_ID          = 0x010C0001;
+static const int MARKER_ID_IMS_CHARGING_ID      = 0x010C0002;
+static const int MARKER_ID_VIA_BRANCH_PARAM     = 0x010C0003;
 
 static const int MARKER_ID_OUTBOUND_CALLING_URI = 0x05000003;
-static const int MARKER_ID_INBOUND_CALLING_URI = 0x05000004;
-static const int MARKER_ID_OUTBOUND_CALLED_URI = 0x05000005;
-static const int MARKER_ID_INBOUND_CALLED_URI = 0x05000006;
+static const int MARKER_ID_INBOUND_CALLING_URI  = 0x05000004;
+static const int MARKER_ID_OUTBOUND_CALLED_URI  = 0x05000005;
+static const int MARKER_ID_INBOUND_CALLED_URI   = 0x05000006;
 
 // SAS::init return codes
-static const int SAS_INIT_RC_OK = 0;
+static const int SAS_INIT_RC_OK  = 0;
 static const int SAS_INIT_RC_ERR = 1;
 
 class SAS


### PR DESCRIPTION
DBAPP code calls 0x01000008 a subscriber num, but a0ced and internal sas client libraries use a consistent name "primary device" - add this to c++ library