### PR TITLE
[Reviewer: Ben] Allow an optional socket factory to be passed to the SAS client (ready to merge)

### DIFF
--- a/include/sas.h
+++ b/include/sas.h
@@ -311,9 +311,14 @@ public:
                                     const char *fmt,
                                     ...);
 
-  // This callback creates the SAS connection socket. It exists primarily so that we can plug in a
-  // cross-namespace socket factory, and create SAS connections in the management namespace rather
-  // than the signaling one,
+  // Optional callback, to create the SAS connection socket in some other way than the 'socket' call.
+  //
+  // For example, this allows callers to use socket control messages
+  // (http://man7.org/linux/man-pages/man3/cmsg.3.html) to get a network socket with enhanced
+  // privileges.
+  //
+  // If this callback isn't provided to SAS::init, we'll use SAS::Connection::get_local_sock by
+  // default.
   typedef int (create_socket_callback_t)(const char* hostname,
                                          const char* port);
 

--- a/include/sas.h
+++ b/include/sas.h
@@ -304,6 +304,10 @@ public:
                                     const char *fmt,
                                     ...);
 
+  typedef int (socket_factory_t)(const char* hostname,
+                                 const char* port);
+
+
   // A simple implementation of sas_log_callback_t that logs messages to stdout.
   static void log_to_stdout(log_level_t level,
                             const char *module,
@@ -322,7 +326,8 @@ public:
                    const std::string& system_type,
                    const std::string& resource_identifier,
                    const std::string& sas_address,
-                   sas_log_callback_t* log_callback);
+                   sas_log_callback_t* log_callback,
+                   socket_factory_t* socket_factory = NULL);
   static void term();
   static TrailId new_trail(uint32_t instance=0u);
   static void report_event(const Event& event);
@@ -355,6 +360,7 @@ private:
   class Connection;
   static Connection* _connection;
   static sas_log_callback_t* _log_callback;
+  static socket_factory_t* _socket_factory;
 };
 
 #endif

--- a/include/sas.h
+++ b/include/sas.h
@@ -311,8 +311,11 @@ public:
                                     const char *fmt,
                                     ...);
 
-  typedef int (socket_factory_t)(const char* hostname,
-                                 const char* port);
+  // This callback creates the SAS connection socket. It exists primarily so that we can plug in a
+  // cross-namespace socket factory, and create SAS connections in the management namespace rather
+  // than the signaling one,
+  typedef int (create_socket_callback_t)(const char* hostname,
+                                         const char* port);
 
 
   // A simple implementation of sas_log_callback_t that logs messages to stdout.
@@ -330,11 +333,11 @@ public:
                            ...);
 
   static int init(const std::string& system_name,
-                   const std::string& system_type,
-                   const std::string& resource_identifier,
-                   const std::string& sas_address,
-                   sas_log_callback_t* log_callback,
-                   socket_factory_t* socket_factory = NULL);
+                  const std::string& system_type,
+                  const std::string& resource_identifier,
+                  const std::string& sas_address,
+                  sas_log_callback_t* log_callback,
+                  create_socket_callback_t* socket_callback = NULL);
   static void term();
   static TrailId new_trail(uint32_t instance=0u);
   static void report_event(const Event& event);
@@ -367,7 +370,7 @@ private:
   class Connection;
   static Connection* _connection;
   static sas_log_callback_t* _log_callback;
-  static socket_factory_t* _socket_factory;
+  static create_socket_callback_t* _socket_callback;
 };
 
 #endif


### PR DESCRIPTION
Alex,

Can you review this change before I send it to the SAS team? This allows sas-client users to optionally pass in a socket factory function, so we can use one of the functions from https://github.com/Metaswitch/cpp-common/pull/362/files that traverse the signaling/management namespace split.

I'll test that I get SAS logs in both a non-traffic-separated and a traffic-separated deployment.