### PR TITLE
[Reviewer: Alex] Faster LZ4 dictionary loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ build: libsas.a
 libsas.a: sas.o sas_compress.o lz4.o
 	ar cr libsas.a $^
 
-C_FLAGS := -Iinclude -std=c99 -Wall -Werror -ggdb3
-CPP_FLAGS := -Iinclude -std=c++0x -Wall -Werror -ggdb3
+C_FLAGS := -O2 -Iinclude -std=c99 -Wall -Werror -ggdb3
+CPP_FLAGS := -O2 -Iinclude -std=c++0x -Wall -Werror -ggdb3
 
 sas.o: source/sas.cpp source/sas_eventq.h source/sas_internal.h include/sas.h include/config.h include/lz4.h
 	g++ ${CPP_FLAGS} -c $<

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ build: libsas.a
 libsas.a: sas.o sas_compress.o lz4.o
 	ar cr libsas.a $^
 
-C_FLAGS := -O2 -Iinclude -std=c99 -Wall -Werror -ggdb3
-CPP_FLAGS := -O2 -Iinclude -std=c++0x -Wall -Werror -ggdb3
+C_FLAGS := -O3 -Iinclude -std=c99 -Wall -Werror -ggdb3
+CPP_FLAGS := -O3 -Iinclude -std=c++0x -Wall -Werror -ggdb3
 
 sas.o: source/sas.cpp source/sas_eventq.h source/sas_internal.h include/sas.h include/config.h include/lz4.h
 	g++ ${CPP_FLAGS} -c $<

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository provides the Service Assurance Server client C++ library.
 
 A makefile is provided to compile the code to an archive file (`libsas.a`), which can be statically linked by applications wishing to use this library.
 
-This repository uses the zlib and LZ4 compression libraries. As LZ4 may not be available in all distributions, it's included as a Git submodule. To check this submodule out, run `git submodule update --init` (or clone the repository with `git clone --recursive ...`).
+This repository uses the zlib and LZ4 compression libraries. As LZ4 may not be available in all distributions, lz4.h and lz4.c are included in this repository and built into `libsas.a`.
 
 To build the library, run `make` in the top level directory. A `clean` target is also supplied.
 

--- a/include/lz4.h
+++ b/include/lz4.h
@@ -219,15 +219,23 @@ int           LZ4_freeStream (LZ4_stream_t* streamPtr);
  */
 int LZ4_loadDict (LZ4_stream_t* streamPtr, const char* dictionary, int dictSize);
 
+
+struct preserved_hash_table {
+  int location;
+  int value;
+};
+
 /* LZ4_stream_preserve
  * Use this function to preserve a stream after loading a dictionary, so it can be rapidly reloaded.
+ *
+ * This allocates buf with as much space as is needed, so the caller must later call free() on it.
  */
-int LZ4_stream_preserve(LZ4_stream_t* stream_, int** buf);
+int LZ4_stream_preserve(LZ4_stream_t* stream_, struct preserved_hash_table** buf);
 
 /* LZ4_stream_restore_preserved
  * Use this function with a new stream and a buffer created by LZ4_stream_preserve, to reload its state
  */
-void LZ4_stream_restore_preserved(LZ4_stream_t* stream_, LZ4_stream_t* orig_, int* buf);
+void LZ4_stream_restore_preserved(LZ4_stream_t* stream_, LZ4_stream_t* orig_, struct preserved_hash_table* buf);
 
 /*
  * LZ4_compress_fast_continue

--- a/include/lz4.h
+++ b/include/lz4.h
@@ -219,6 +219,16 @@ int           LZ4_freeStream (LZ4_stream_t* streamPtr);
  */
 int LZ4_loadDict (LZ4_stream_t* streamPtr, const char* dictionary, int dictSize);
 
+/* LZ4_stream_preserve
+ * Use this function to preserve a stream after loading a dictionary, so it can be rapidly reloaded.
+ */
+int LZ4_stream_preserve(LZ4_stream_t* stream_, int** buf);
+
+/* LZ4_stream_restore_preserved
+ * Use this function with a new stream and a buffer created by LZ4_stream_preserve, to reload its state
+ */
+void LZ4_stream_restore_preserved(LZ4_stream_t* stream_, LZ4_stream_t* orig_, int* buf);
+
 /*
  * LZ4_compress_fast_continue
  * Compress buffer content 'src', using data from previously compressed blocks as dictionary to improve compression ratio.

--- a/include/lz4.h
+++ b/include/lz4.h
@@ -220,7 +220,7 @@ int           LZ4_freeStream (LZ4_stream_t* streamPtr);
 int LZ4_loadDict (LZ4_stream_t* streamPtr, const char* dictionary, int dictSize);
 
 
-struct preserved_hash_table_entry {
+struct preserved_hash_table_entry_t {
   int location;
   int value;
 };
@@ -230,12 +230,12 @@ struct preserved_hash_table_entry {
  *
  * This allocates buf with as much space as is needed, so the caller must later call free() on it.
  */
-int LZ4_stream_preserve(LZ4_stream_t* stream_, struct preserved_hash_table_entry** buf);
+int LZ4_stream_preserve(LZ4_stream_t* stream_, struct preserved_hash_table_entry_t** buf);
 
 /* LZ4_stream_restore_preserved
  * Use this function with a new stream and a buffer created by LZ4_stream_preserve, to reload its state
  */
-void LZ4_stream_restore_preserved(LZ4_stream_t* stream_, LZ4_stream_t* orig_, struct preserved_hash_table_entry* buf);
+void LZ4_stream_restore_preserved(LZ4_stream_t* stream_, LZ4_stream_t* orig_, struct preserved_hash_table_entry_t* buf);
 
 /*
  * LZ4_compress_fast_continue

--- a/include/lz4.h
+++ b/include/lz4.h
@@ -220,7 +220,7 @@ int           LZ4_freeStream (LZ4_stream_t* streamPtr);
 int LZ4_loadDict (LZ4_stream_t* streamPtr, const char* dictionary, int dictSize);
 
 
-struct preserved_hash_table {
+struct preserved_hash_table_entry {
   int location;
   int value;
 };
@@ -230,12 +230,12 @@ struct preserved_hash_table {
  *
  * This allocates buf with as much space as is needed, so the caller must later call free() on it.
  */
-int LZ4_stream_preserve(LZ4_stream_t* stream_, struct preserved_hash_table** buf);
+int LZ4_stream_preserve(LZ4_stream_t* stream_, struct preserved_hash_table_entry** buf);
 
 /* LZ4_stream_restore_preserved
  * Use this function with a new stream and a buffer created by LZ4_stream_preserve, to reload its state
  */
-void LZ4_stream_restore_preserved(LZ4_stream_t* stream_, LZ4_stream_t* orig_, struct preserved_hash_table* buf);
+void LZ4_stream_restore_preserved(LZ4_stream_t* stream_, LZ4_stream_t* orig_, struct preserved_hash_table_entry* buf);
 
 /*
  * LZ4_compress_fast_continue

--- a/include/sas.h
+++ b/include/sas.h
@@ -45,7 +45,6 @@
 #include <string.h>
 #include <string>
 #include <vector>
-#include <lz4.h>
 
 #if HAVE_ATOMIC
   #include <atomic>

--- a/include/sas.h
+++ b/include/sas.h
@@ -122,16 +122,13 @@ public:
 
     Profile(std::string dictionary, Algorithm a = ZLIB);
     Profile(Algorithm a);
-    ~Profile() { LZ4_freeStream(_stream); free(_stream_saved_buf); };
+    ~Profile() {};
     inline const std::string& get_dictionary() const {return _dictionary;}
     inline Algorithm get_algorithm() const {return _algorithm;}
-    void get_stream(LZ4_stream_t* stream) const;
 
   private:
     const std::string _dictionary;
     const Algorithm _algorithm;
-    LZ4_stream_t* _stream;
-    struct preserved_hash_table* _stream_saved_buf;
   };
 
   class Compressor

--- a/include/sas.h
+++ b/include/sas.h
@@ -45,6 +45,7 @@
 #include <string.h>
 #include <string>
 #include <vector>
+#include <lz4.h>
 
 #if HAVE_ATOMIC
   #include <atomic>
@@ -119,20 +120,24 @@ public:
       LZ4
     };
 
-    inline Profile(std::string dictionary, Algorithm a = ZLIB) : _dictionary(dictionary), _algorithm(a) {}
-    inline Profile(Algorithm a) : _dictionary(""), _algorithm(a) {}
+    Profile(std::string dictionary, Algorithm a = ZLIB);
+    Profile(Algorithm a);
+    ~Profile() { LZ4_freeStream(_stream); free(_stream_saved_buf); };
     inline const std::string& get_dictionary() const {return _dictionary;}
     inline Algorithm get_algorithm() const {return _algorithm;}
+    void get_stream(LZ4_stream_t* stream) const;
 
   private:
     const std::string _dictionary;
     const Algorithm _algorithm;
+    LZ4_stream_t* _stream;
+    int* _stream_saved_buf;
   };
 
   class Compressor
   {
   public:
-    virtual std::string compress(const std::string& s, std::string dictionary) = 0;
+    virtual std::string compress(const std::string& s, const Profile* profile) = 0;
     static Compressor* get(Profile::Algorithm algorithm);
 
   protected:
@@ -196,17 +201,15 @@ public:
     {
       // Default compression is zlib with no dictionary
       Profile::Algorithm algorithm = Profile::Algorithm::ZLIB;
-      std::string dictionary = "";
 
       // If a profile is provided, override those defaults
       if (profile != NULL)
       {
         algorithm = profile->get_algorithm();
-        dictionary = profile->get_dictionary();
       }
 
       Compressor* compressor = SAS::Compressor::get(algorithm);
-      return add_var_param(compressor->compress(s, dictionary));
+      return add_var_param(compressor->compress(s, profile));
     }
 
     inline Message& add_compressed_param(size_t len, char* s, const Profile* profile = NULL)

--- a/include/sas.h
+++ b/include/sas.h
@@ -131,7 +131,7 @@ public:
     const std::string _dictionary;
     const Algorithm _algorithm;
     LZ4_stream_t* _stream;
-    int* _stream_saved_buf;
+    struct preserved_hash_table* _stream_saved_buf;
   };
 
   class Compressor

--- a/source/lz4.c
+++ b/source/lz4.c
@@ -986,6 +986,47 @@ int LZ4_loadDict (LZ4_stream_t* LZ4_dict, const char* dictionary, int dictSize)
     return dict->dictSize;
 }
 
+int LZ4_stream_preserve(LZ4_stream_t* stream_, int** buf_out)
+{
+  int nbytes = sizeof(int) * HASH_SIZE_U32;
+  int* buf = malloc(nbytes);
+  memset(buf, 0, nbytes);
+  *buf_out = buf;
+  LZ4_stream_t_internal* stream = (LZ4_stream_t_internal*)stream_;
+  int buf_pos = 0;
+  for (int i = 0; i < HASH_SIZE_U32; i++)
+  {
+    if (stream->hashTable[i] != 0)
+    {
+      buf[buf_pos] = i;
+      buf_pos++;
+    }
+  }
+  return buf_pos;
+}
+
+void LZ4_stream_restore_preserved(LZ4_stream_t* stream_, LZ4_stream_t* orig_, int* buf)
+{
+  LZ4_stream_t_internal* orig = (LZ4_stream_t_internal*)orig_;
+  LZ4_stream_t_internal* stream = (LZ4_stream_t_internal*)stream_;
+  stream->currentOffset = orig->currentOffset;
+  stream->dictionary = orig->dictionary;
+  stream->bufferStart = orig->bufferStart;
+  stream->dictSize = orig->dictSize;
+
+  for (int i = 0; i < HASH_SIZE_U32; i++)
+  {
+    int loc = buf[i];
+    if (loc)
+    {
+      stream->hashTable[loc] = orig->hashTable[loc];
+    }
+    else
+    {
+      break;
+    }
+  }
+}
 
 static void LZ4_renormDictT(LZ4_stream_t_internal* LZ4_dict, const BYTE* src)
 {

--- a/source/lz4.c
+++ b/source/lz4.c
@@ -990,7 +990,7 @@ int LZ4_stream_preserve(LZ4_stream_t* stream_, int** buf_out)
 {
   int nbytes = sizeof(int) * HASH_SIZE_U32;
   int* buf = malloc(nbytes);
-  memset(buf, 0, nbytes);
+  memset(buf, -1, nbytes);
   *buf_out = buf;
   LZ4_stream_t_internal* stream = (LZ4_stream_t_internal*)stream_;
   int buf_pos = 0;
@@ -1017,7 +1017,7 @@ void LZ4_stream_restore_preserved(LZ4_stream_t* stream_, LZ4_stream_t* orig_, in
   for (int i = 0; i < HASH_SIZE_U32; i++)
   {
     int loc = buf[i];
-    if (loc)
+    if (loc != -1)
     {
       stream->hashTable[loc] = orig->hashTable[loc];
     }

--- a/source/lz4.c
+++ b/source/lz4.c
@@ -986,7 +986,7 @@ int LZ4_loadDict (LZ4_stream_t* LZ4_dict, const char* dictionary, int dictSize)
     return dict->dictSize;
 }
 
-int LZ4_stream_preserve(LZ4_stream_t* stream_, struct preserved_hash_table** buf_out)
+int LZ4_stream_preserve(LZ4_stream_t* stream_, struct preserved_hash_table_entry** buf_out)
 {
   LZ4_stream_t_internal* stream = (LZ4_stream_t_internal*)stream_;
 
@@ -1002,8 +1002,8 @@ int LZ4_stream_preserve(LZ4_stream_t* stream_, struct preserved_hash_table** buf
   // Add an extra location - this holds the sentinel value to indicate we're at the end of the array
   num_locs_needed += 1;
 
-  int nbytes = sizeof(struct preserved_hash_table) * num_locs_needed;
-  struct preserved_hash_table* buf = malloc(nbytes);
+  int nbytes = sizeof(struct preserved_hash_table_entry) * num_locs_needed;
+  struct preserved_hash_table_entry* buf = malloc(nbytes);
   memset(buf, -1, nbytes);
   *buf_out = buf;
   int buf_pos = 0;
@@ -1019,7 +1019,7 @@ int LZ4_stream_preserve(LZ4_stream_t* stream_, struct preserved_hash_table** buf
   return buf_pos;
 }
 
-void LZ4_stream_restore_preserved(LZ4_stream_t* stream_, LZ4_stream_t* orig_, struct preserved_hash_table* buf)
+void LZ4_stream_restore_preserved(LZ4_stream_t* stream_, LZ4_stream_t* orig_, struct preserved_hash_table_entry* buf)
 {
   LZ4_stream_t_internal* orig = (LZ4_stream_t_internal*)orig_;
   LZ4_stream_t_internal* stream = (LZ4_stream_t_internal*)stream_;

--- a/source/lz4.c
+++ b/source/lz4.c
@@ -988,11 +988,24 @@ int LZ4_loadDict (LZ4_stream_t* LZ4_dict, const char* dictionary, int dictSize)
 
 int LZ4_stream_preserve(LZ4_stream_t* stream_, struct preserved_hash_table** buf_out)
 {
-  int nbytes = sizeof(struct preserved_hash_table) * HASH_SIZE_U32;
+  LZ4_stream_t_internal* stream = (LZ4_stream_t_internal*)stream_;
+
+  int num_locs_needed = 0;
+  for (int i = 0; i < HASH_SIZE_U32; i++)
+  {
+    if (stream->hashTable[i] != 0)
+    {
+      num_locs_needed++;
+    }
+  }
+
+  // Add an extra location - this holds the sentinel value to indicate we're at the end of the array
+  num_locs_needed += 1;
+
+  int nbytes = sizeof(struct preserved_hash_table) * num_locs_needed;
   struct preserved_hash_table* buf = malloc(nbytes);
   memset(buf, -1, nbytes);
   *buf_out = buf;
-  LZ4_stream_t_internal* stream = (LZ4_stream_t_internal*)stream_;
   int buf_pos = 0;
   for (int i = 0; i < HASH_SIZE_U32; i++)
   {

--- a/source/lz4.c
+++ b/source/lz4.c
@@ -986,7 +986,7 @@ int LZ4_loadDict (LZ4_stream_t* LZ4_dict, const char* dictionary, int dictSize)
     return dict->dictSize;
 }
 
-int LZ4_stream_preserve(LZ4_stream_t* stream_, struct preserved_hash_table_entry** buf_out)
+int LZ4_stream_preserve(LZ4_stream_t* stream_, struct preserved_hash_table_entry_t** buf_out)
 {
   LZ4_stream_t_internal* stream = (LZ4_stream_t_internal*)stream_;
 
@@ -1002,9 +1002,8 @@ int LZ4_stream_preserve(LZ4_stream_t* stream_, struct preserved_hash_table_entry
   // Add an extra location - this holds the sentinel value to indicate we're at the end of the array
   num_locs_needed += 1;
 
-  int nbytes = sizeof(struct preserved_hash_table_entry) * num_locs_needed;
-  struct preserved_hash_table_entry* buf = malloc(nbytes);
-  memset(buf, -1, nbytes);
+  int nbytes = sizeof(struct preserved_hash_table_entry_t) * num_locs_needed;
+  struct preserved_hash_table_entry_t* buf = malloc(nbytes);
   *buf_out = buf;
   int buf_pos = 0;
   for (int i = 0; i < HASH_SIZE_U32; i++)
@@ -1016,10 +1015,14 @@ int LZ4_stream_preserve(LZ4_stream_t* stream_, struct preserved_hash_table_entry
       buf_pos++;
     }
   }
+
+  // Set a sentinel -1 value at the end of the array
+  buf[buf_pos].location = -1;
+  buf[buf_pos].value = -1;
   return buf_pos;
 }
 
-void LZ4_stream_restore_preserved(LZ4_stream_t* stream_, LZ4_stream_t* orig_, struct preserved_hash_table_entry* buf)
+void LZ4_stream_restore_preserved(LZ4_stream_t* stream_, LZ4_stream_t* orig_, struct preserved_hash_table_entry_t* buf)
 {
   LZ4_stream_t_internal* orig = (LZ4_stream_t_internal*)orig_;
   LZ4_stream_t_internal* stream = (LZ4_stream_t_internal*)stream_;

--- a/source/sas_compress.cpp
+++ b/source/sas_compress.cpp
@@ -70,7 +70,7 @@ private:
   char _buffer[4096];
 };
 
-typedef std::pair<LZ4_stream_t*, struct preserved_hash_table_entry*> saved_lz4_stream ;
+typedef std::pair<LZ4_stream_t*, struct preserved_hash_table_entry_t*> saved_lz4_stream ;
 
 class LZ4Compressor : public SAS::Compressor
 {
@@ -289,7 +289,7 @@ std::string LZ4Compressor::compress(const std::string& s, const SAS::Profile* pr
     {
       // Set up and cache the stream
       LZ4_stream_t* base_stream = LZ4_createStream();
-      struct preserved_hash_table_entry* stream_saved_buf;
+      struct preserved_hash_table_entry_t* stream_saved_buf;
       LZ4_loadDict(base_stream, profile->get_dictionary().c_str(), profile->get_dictionary().length());
       LZ4_stream_preserve(base_stream, &stream_saved_buf);
       _saved_streams[profile] = saved_lz4_stream(base_stream, stream_saved_buf);

--- a/source/sas_compress.cpp
+++ b/source/sas_compress.cpp
@@ -42,6 +42,7 @@
 #include <sys/socket.h>
 #include <unordered_map>
 
+#include <lz4.h>
 #include <zlib.h>
 
 #include "sas.h"

--- a/source/sas_compress.cpp
+++ b/source/sas_compress.cpp
@@ -40,6 +40,7 @@
 #include <netdb.h>
 #include <stdarg.h>
 #include <sys/socket.h>
+#include <unordered_map>
 
 #include <zlib.h>
 
@@ -68,6 +69,8 @@ private:
   char _buffer[4096];
 };
 
+typedef std::pair<LZ4_stream_t*, struct preserved_hash_table*> saved_lz4_stream ;
+
 class LZ4Compressor : public SAS::Compressor
 {
 public:
@@ -93,6 +96,8 @@ private:
 
   LZ4_stream_t* _stream;
   char _buffer[LZ4_COMPRESSBOUND(MAX_INPUT_SIZE)];
+
+  std::unordered_map<const SAS::Profile*, saved_lz4_stream> _saved_streams;
 };
 
 pthread_once_t ZlibCompressor::_once = PTHREAD_ONCE_INIT;
@@ -125,9 +130,6 @@ SAS::Profile::Profile(std::string dictionary, Profile::Algorithm a) :
   _algorithm(a)
 
 {
-  _stream = LZ4_createStream();
-  LZ4_loadDict(_stream, dictionary.c_str(), dictionary.length());
-  LZ4_stream_preserve(_stream, &_stream_saved_buf);
 }
 
 SAS::Profile::Profile(Profile::Algorithm a) :
@@ -135,15 +137,8 @@ SAS::Profile::Profile(Profile::Algorithm a) :
   _algorithm(a)
 
 {
-  _stream = LZ4_createStream();
-  LZ4_stream_preserve(_stream, &_stream_saved_buf);
 }
 
-
-void SAS::Profile::get_stream(LZ4_stream_t* stream) const
-{
-  LZ4_stream_restore_preserved(stream, _stream, _stream_saved_buf);
-}
 
 /// Get a thread-scope Compressor, or create one if it doesn't exist already.
 SAS::Compressor* SAS::Compressor::get(SAS::Profile::Algorithm algorithm)
@@ -272,6 +267,14 @@ LZ4Compressor::~LZ4Compressor()
   // Free the stream.  Ignore the return code - the interface doesn't define
   // its meaning, and it's currently hard-coded to 0.
   (void)LZ4_freeStream(_stream); _stream = NULL;
+
+  for (std::unordered_map<const SAS::Profile*, saved_lz4_stream>::iterator saved_stream_iterator = _saved_streams.begin();
+       saved_stream_iterator != _saved_streams.end();
+       saved_stream_iterator++)
+  {
+    LZ4_freeStream(saved_stream_iterator->second.first);
+    free(saved_stream_iterator->second.second);
+  }
 }
 
 /// Compresses the specified string using the dictionary from the profile (if non-empty).
@@ -279,7 +282,22 @@ std::string LZ4Compressor::compress(const std::string& s, const SAS::Profile* pr
 {
   if (profile)
   {
-    profile->get_stream(_stream);
+    std::unordered_map<const SAS::Profile*, saved_lz4_stream>::iterator saved_stream_iterator = _saved_streams.find(profile);
+
+    if (saved_stream_iterator == _saved_streams.end())
+    {
+      // Set up and cache the stream
+      LZ4_stream_t* base_stream = LZ4_createStream();
+      struct preserved_hash_table* stream_saved_buf;
+      LZ4_loadDict(base_stream, profile->get_dictionary().c_str(), profile->get_dictionary().length());
+      LZ4_stream_preserve(base_stream, &stream_saved_buf);
+      _saved_streams[profile] = saved_lz4_stream(base_stream, stream_saved_buf);
+      saved_stream_iterator = _saved_streams.find(profile);
+    }
+    
+    LZ4_stream_restore_preserved(_stream,
+                                 saved_stream_iterator->second.first,
+                                 saved_stream_iterator->second.second);
   }
 
   // Spin round, compressing up to a buffer's worth of input and appending it to the string.

--- a/source/sas_compress.cpp
+++ b/source/sas_compress.cpp
@@ -70,7 +70,7 @@ private:
   char _buffer[4096];
 };
 
-typedef std::pair<LZ4_stream_t*, struct preserved_hash_table*> saved_lz4_stream ;
+typedef std::pair<LZ4_stream_t*, struct preserved_hash_table_entry*> saved_lz4_stream ;
 
 class LZ4Compressor : public SAS::Compressor
 {
@@ -289,7 +289,7 @@ std::string LZ4Compressor::compress(const std::string& s, const SAS::Profile* pr
     {
       // Set up and cache the stream
       LZ4_stream_t* base_stream = LZ4_createStream();
-      struct preserved_hash_table* stream_saved_buf;
+      struct preserved_hash_table_entry* stream_saved_buf;
       LZ4_loadDict(base_stream, profile->get_dictionary().c_str(), profile->get_dictionary().length());
       LZ4_stream_preserve(base_stream, &stream_saved_buf);
       _saved_streams[profile] = saved_lz4_stream(base_stream, stream_saved_buf);

--- a/source/ut/main_compress.cpp
+++ b/source/ut/main_compress.cpp
@@ -43,6 +43,10 @@
 namespace CompressionTest
 {
 
+SAS::Profile zlib_profile("hello world");
+SAS::Profile lz4_profile(SAS::Profile::Algorithm::LZ4);
+SAS::Profile lz4_dict_profile("Test string.", SAS::Profile::Algorithm::LZ4);
+
 void test_hello_world()
 {
   SAS::Event event(1, 2, 3);
@@ -68,9 +72,8 @@ void test_hello_world()
 
 void test_dictionary()
 {
-  SAS::Profile profile("hello world");
   SAS::Event event(1, 2, 3);
-  event.add_compressed_param("hello world\n", &profile);
+  event.add_compressed_param("hello world\n", &zlib_profile);
   std::string bytes = event.to_string();
 
   SasTest::Event expected;
@@ -91,9 +94,8 @@ void test_dictionary()
 
 void test_hello_world_lz4()
 {
-  SAS::Profile profile(SAS::Profile::Algorithm::LZ4);
   SAS::Event event(1, 2, 3);
-  event.add_compressed_param("Test string.  Test string.\n", &profile);
+  event.add_compressed_param("Test string.  Test string.\n", &lz4_profile);
   std::string bytes = event.to_string();
 
   SasTest::Event expected;
@@ -115,9 +117,8 @@ void test_hello_world_lz4()
 
 void test_dictionary_lz4()
 {
-  SAS::Profile profile("Test string.", SAS::Profile::Algorithm::LZ4);
   SAS::Event event(1, 2, 3);
-  event.add_compressed_param("Test string.  Test string.\n", &profile);
+  event.add_compressed_param("Test string.  Test string.\n", &lz4_dict_profile);
   std::string bytes = event.to_string();
 
   SasTest::Event expected;

--- a/source/ut/main_compress.cpp
+++ b/source/ut/main_compress.cpp
@@ -91,7 +91,7 @@ void test_dictionary()
 
 void test_hello_world_lz4()
 {
-  SAS::Profile profile(SAS::Profile::CompressionType::LZ4);
+  SAS::Profile profile(SAS::Profile::Algorithm::LZ4);
   SAS::Event event(1, 2, 3);
   event.add_compressed_param("Test string.  Test string.\n", &profile);
   std::string bytes = event.to_string();
@@ -115,7 +115,7 @@ void test_hello_world_lz4()
 
 void test_dictionary_lz4()
 {
-  SAS::Profile profile("Test string.", SAS::Profile::CompressionType::LZ4);
+  SAS::Profile profile("Test string.", SAS::Profile::Algorithm::LZ4);
   SAS::Event event(1, 2, 3);
   event.add_compressed_param("Test string.  Test string.\n", &profile);
   std::string bytes = event.to_string();


### PR DESCRIPTION
Testing with callgrind shows that LZ4_stream_restore_preserved uses about 2/3rds the CPU instructions of LZ4_loadDict - as Sprout spends about 3% of its time loading dictionaries, this is a 1% boost to overall Sprout performance.