### PR TITLE
Faster dictionary compression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ build: libsas.a
 libsas.a: sas.o sas_compress.o lz4.o
 	ar cr libsas.a $^
 
-C_FLAGS := -Iinclude -std=c99 -Wall -Werror -ggdb3
-CPP_FLAGS := -Iinclude -std=c++0x -Wall -Werror -ggdb3
+C_FLAGS := -O2 -Iinclude -std=c99 -Wall -Werror -ggdb3
+CPP_FLAGS := -O2 -Iinclude -std=c++0x -Wall -Werror -ggdb3
 
 sas.o: source/sas.cpp source/sas_eventq.h source/sas_internal.h include/sas.h include/config.h include/lz4.h
 	g++ ${CPP_FLAGS} -c $<

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ build: libsas.a
 libsas.a: sas.o sas_compress.o lz4.o
 	ar cr libsas.a $^
 
-C_FLAGS := -O2 -Iinclude -std=c99 -Wall -Werror -ggdb3
-CPP_FLAGS := -O2 -Iinclude -std=c++0x -Wall -Werror -ggdb3
+C_FLAGS := -O3 -Iinclude -std=c99 -Wall -Werror -ggdb3
+CPP_FLAGS := -O3 -Iinclude -std=c++0x -Wall -Werror -ggdb3
 
 sas.o: source/sas.cpp source/sas_eventq.h source/sas_internal.h include/sas.h include/config.h include/lz4.h
 	g++ ${CPP_FLAGS} -c $<

--- a/include/lz4.h
+++ b/include/lz4.h
@@ -219,15 +219,23 @@ int           LZ4_freeStream (LZ4_stream_t* streamPtr);
  */
 int LZ4_loadDict (LZ4_stream_t* streamPtr, const char* dictionary, int dictSize);
 
+
+struct preserved_hash_table_entry_t {
+  int location;
+  int value;
+};
+
 /* LZ4_stream_preserve
  * Use this function to preserve a stream after loading a dictionary, so it can be rapidly reloaded.
+ *
+ * This allocates buf with as much space as is needed, so the caller must later call free() on it.
  */
-int LZ4_stream_preserve(LZ4_stream_t* stream_, int** buf);
+int LZ4_stream_preserve(LZ4_stream_t* stream_, struct preserved_hash_table_entry_t** buf);
 
 /* LZ4_stream_restore_preserved
  * Use this function with a new stream and a buffer created by LZ4_stream_preserve, to reload its state
  */
-void LZ4_stream_restore_preserved(LZ4_stream_t* stream_, LZ4_stream_t* orig_, int* buf);
+void LZ4_stream_restore_preserved(LZ4_stream_t* stream_, LZ4_stream_t* orig_, struct preserved_hash_table_entry_t* buf);
 
 /*
  * LZ4_compress_fast_continue

--- a/include/lz4.h
+++ b/include/lz4.h
@@ -219,6 +219,16 @@ int           LZ4_freeStream (LZ4_stream_t* streamPtr);
  */
 int LZ4_loadDict (LZ4_stream_t* streamPtr, const char* dictionary, int dictSize);
 
+/* LZ4_stream_preserve
+ * Use this function to preserve a stream after loading a dictionary, so it can be rapidly reloaded.
+ */
+int LZ4_stream_preserve(LZ4_stream_t* stream_, int** buf);
+
+/* LZ4_stream_restore_preserved
+ * Use this function with a new stream and a buffer created by LZ4_stream_preserve, to reload its state
+ */
+void LZ4_stream_restore_preserved(LZ4_stream_t* stream_, LZ4_stream_t* orig_, int* buf);
+
 /*
  * LZ4_compress_fast_continue
  * Compress buffer content 'src', using data from previously compressed blocks as dictionary to improve compression ratio.

--- a/include/sas.h
+++ b/include/sas.h
@@ -45,7 +45,6 @@
 #include <string.h>
 #include <string>
 #include <vector>
-#include <lz4.h>
 
 #if HAVE_ATOMIC
   #include <atomic>
@@ -122,16 +121,13 @@ public:
 
     Profile(std::string dictionary, Algorithm a = ZLIB);
     Profile(Algorithm a);
-    ~Profile() { LZ4_freeStream(_stream); free(_stream_saved_buf); };
+    ~Profile() {};
     inline const std::string& get_dictionary() const {return _dictionary;}
     inline Algorithm get_algorithm() const {return _algorithm;}
-    void get_stream(LZ4_stream_t* stream) const;
 
   private:
     const std::string _dictionary;
     const Algorithm _algorithm;
-    LZ4_stream_t* _stream;
-    int* _stream_saved_buf;
   };
 
   class Compressor

--- a/include/sas.h
+++ b/include/sas.h
@@ -119,8 +119,10 @@ public:
       LZ4
     };
 
-    Profile(std::string dictionary, Algorithm a = ZLIB);
-    Profile(Algorithm a);
+    Profile(std::string dictionary, Algorithm a = ZLIB):
+      _dictionary(dictionary),_algorithm(a) {};
+    Profile(Algorithm a):
+      _dictionary(""),_algorithm(a) {};
     ~Profile() {};
     inline const std::string& get_dictionary() const {return _dictionary;}
     inline Algorithm get_algorithm() const {return _algorithm;}

--- a/include/sas.h
+++ b/include/sas.h
@@ -45,6 +45,7 @@
 #include <string.h>
 #include <string>
 #include <vector>
+#include <lz4.h>
 
 #if HAVE_ATOMIC
   #include <atomic>
@@ -119,20 +120,24 @@ public:
       LZ4
     };
 
-    inline Profile(std::string dictionary, Algorithm a = ZLIB) : _dictionary(dictionary), _algorithm(a) {}
-    inline Profile(Algorithm a) : _dictionary(""), _algorithm(a) {}
+    Profile(std::string dictionary, Algorithm a = ZLIB);
+    Profile(Algorithm a);
+    ~Profile() { LZ4_freeStream(_stream); free(_stream_saved_buf); };
     inline const std::string& get_dictionary() const {return _dictionary;}
     inline Algorithm get_algorithm() const {return _algorithm;}
+    void get_stream(LZ4_stream_t* stream) const;
 
   private:
     const std::string _dictionary;
     const Algorithm _algorithm;
+    LZ4_stream_t* _stream;
+    int* _stream_saved_buf;
   };
 
   class Compressor
   {
   public:
-    virtual std::string compress(const std::string& s, std::string dictionary) = 0;
+    virtual std::string compress(const std::string& s, const Profile* profile) = 0;
     static Compressor* get(Profile::Algorithm algorithm);
 
   protected:
@@ -196,17 +201,15 @@ public:
     {
       // Default compression is zlib with no dictionary
       Profile::Algorithm algorithm = Profile::Algorithm::ZLIB;
-      std::string dictionary = "";
 
       // If a profile is provided, override those defaults
       if (profile != NULL)
       {
         algorithm = profile->get_algorithm();
-        dictionary = profile->get_dictionary();
       }
 
       Compressor* compressor = SAS::Compressor::get(algorithm);
-      return add_var_param(compressor->compress(s, dictionary));
+      return add_var_param(compressor->compress(s, profile));
     }
 
     inline Message& add_compressed_param(size_t len, char* s, const Profile* profile = NULL)

--- a/source/lz4.c
+++ b/source/lz4.c
@@ -986,6 +986,47 @@ int LZ4_loadDict (LZ4_stream_t* LZ4_dict, const char* dictionary, int dictSize)
     return dict->dictSize;
 }
 
+int LZ4_stream_preserve(LZ4_stream_t* stream_, int** buf_out)
+{
+  int nbytes = sizeof(int) * HASH_SIZE_U32;
+  int* buf = malloc(nbytes);
+  memset(buf, -1, nbytes);
+  *buf_out = buf;
+  LZ4_stream_t_internal* stream = (LZ4_stream_t_internal*)stream_;
+  int buf_pos = 0;
+  for (int i = 0; i < HASH_SIZE_U32; i++)
+  {
+    if (stream->hashTable[i] != 0)
+    {
+      buf[buf_pos] = i;
+      buf_pos++;
+    }
+  }
+  return buf_pos;
+}
+
+void LZ4_stream_restore_preserved(LZ4_stream_t* stream_, LZ4_stream_t* orig_, int* buf)
+{
+  LZ4_stream_t_internal* orig = (LZ4_stream_t_internal*)orig_;
+  LZ4_stream_t_internal* stream = (LZ4_stream_t_internal*)stream_;
+  stream->currentOffset = orig->currentOffset;
+  stream->dictionary = orig->dictionary;
+  stream->bufferStart = orig->bufferStart;
+  stream->dictSize = orig->dictSize;
+
+  for (int i = 0; i < HASH_SIZE_U32; i++)
+  {
+    int loc = buf[i];
+    if (loc != -1)
+    {
+      stream->hashTable[loc] = orig->hashTable[loc];
+    }
+    else
+    {
+      break;
+    }
+  }
+}
 
 static void LZ4_renormDictT(LZ4_stream_t_internal* LZ4_dict, const BYTE* src)
 {

--- a/source/lz4.c
+++ b/source/lz4.c
@@ -986,26 +986,43 @@ int LZ4_loadDict (LZ4_stream_t* LZ4_dict, const char* dictionary, int dictSize)
     return dict->dictSize;
 }
 
-int LZ4_stream_preserve(LZ4_stream_t* stream_, int** buf_out)
+int LZ4_stream_preserve(LZ4_stream_t* stream_, struct preserved_hash_table_entry_t** buf_out)
 {
-  int nbytes = sizeof(int) * HASH_SIZE_U32;
-  int* buf = malloc(nbytes);
-  memset(buf, -1, nbytes);
-  *buf_out = buf;
   LZ4_stream_t_internal* stream = (LZ4_stream_t_internal*)stream_;
+
+  int num_locs_needed = 0;
+  for (int i = 0; i < HASH_SIZE_U32; i++)
+  {
+    if (stream->hashTable[i] != 0)
+    {
+      num_locs_needed++;
+    }
+  }
+
+  // Add an extra location - this holds the sentinel value to indicate we're at the end of the array
+  num_locs_needed += 1;
+
+  int nbytes = sizeof(struct preserved_hash_table_entry_t) * num_locs_needed;
+  struct preserved_hash_table_entry_t* buf = malloc(nbytes);
+  *buf_out = buf;
   int buf_pos = 0;
   for (int i = 0; i < HASH_SIZE_U32; i++)
   {
     if (stream->hashTable[i] != 0)
     {
-      buf[buf_pos] = i;
+      buf[buf_pos].location = i;
+      buf[buf_pos].value = stream->hashTable[i];
       buf_pos++;
     }
   }
+
+  // Set a sentinel -1 value at the end of the array
+  buf[buf_pos].location = -1;
+  buf[buf_pos].value = -1;
   return buf_pos;
 }
 
-void LZ4_stream_restore_preserved(LZ4_stream_t* stream_, LZ4_stream_t* orig_, int* buf)
+void LZ4_stream_restore_preserved(LZ4_stream_t* stream_, LZ4_stream_t* orig_, struct preserved_hash_table_entry_t* buf)
 {
   LZ4_stream_t_internal* orig = (LZ4_stream_t_internal*)orig_;
   LZ4_stream_t_internal* stream = (LZ4_stream_t_internal*)stream_;
@@ -1016,10 +1033,9 @@ void LZ4_stream_restore_preserved(LZ4_stream_t* stream_, LZ4_stream_t* orig_, in
 
   for (int i = 0; i < HASH_SIZE_U32; i++)
   {
-    int loc = buf[i];
-    if (loc != -1)
+    if (buf[i].location != -1)
     {
-      stream->hashTable[loc] = orig->hashTable[loc];
+      stream->hashTable[buf[i].location] = buf[i].value;
     }
     else
     {

--- a/source/sas_compress.cpp
+++ b/source/sas_compress.cpp
@@ -126,21 +126,6 @@ void LZ4Compressor::init()
   }
 }
 
-SAS::Profile::Profile(std::string dictionary, Profile::Algorithm a) :
-  _dictionary(dictionary),
-  _algorithm(a)
-
-{
-}
-
-SAS::Profile::Profile(Profile::Algorithm a) :
-  _dictionary(""),
-  _algorithm(a)
-
-{
-}
-
-
 /// Get a thread-scope Compressor, or create one if it doesn't exist already.
 SAS::Compressor* SAS::Compressor::get(SAS::Profile::Algorithm algorithm)
 {

--- a/source/ut/main_compress.cpp
+++ b/source/ut/main_compress.cpp
@@ -91,7 +91,7 @@ void test_dictionary()
 
 void test_hello_world_lz4()
 {
-  SAS::Profile profile(SAS::Profile::CompressionType::LZ4);
+  SAS::Profile profile(SAS::Profile::Algorithm::LZ4);
   SAS::Event event(1, 2, 3);
   event.add_compressed_param("Test string.  Test string.\n", &profile);
   std::string bytes = event.to_string();
@@ -115,7 +115,7 @@ void test_hello_world_lz4()
 
 void test_dictionary_lz4()
 {
-  SAS::Profile profile("Test string.", SAS::Profile::CompressionType::LZ4);
+  SAS::Profile profile("Test string.", SAS::Profile::Algorithm::LZ4);
   SAS::Event event(1, 2, 3);
   event.add_compressed_param("Test string.  Test string.\n", &profile);
   std::string bytes = event.to_string();

--- a/source/ut/main_compress.cpp
+++ b/source/ut/main_compress.cpp
@@ -43,6 +43,12 @@
 namespace CompressionTest
 {
 
+// Profiles need to be static (matching how they're used in real code)
+// so that the compressors can match them to the saved streams.
+SAS::Profile zlib_profile("hello world");
+SAS::Profile lz4_profile(SAS::Profile::Algorithm::LZ4);
+SAS::Profile lz4_dict_profile("Test string.", SAS::Profile::Algorithm::LZ4);
+
 void test_hello_world()
 {
   SAS::Event event(1, 2, 3);
@@ -68,9 +74,8 @@ void test_hello_world()
 
 void test_dictionary()
 {
-  SAS::Profile profile("hello world");
   SAS::Event event(1, 2, 3);
-  event.add_compressed_param("hello world\n", &profile);
+  event.add_compressed_param("hello world\n", &zlib_profile);
   std::string bytes = event.to_string();
 
   SasTest::Event expected;
@@ -91,9 +96,8 @@ void test_dictionary()
 
 void test_hello_world_lz4()
 {
-  SAS::Profile profile(SAS::Profile::Algorithm::LZ4);
   SAS::Event event(1, 2, 3);
-  event.add_compressed_param("Test string.  Test string.\n", &profile);
+  event.add_compressed_param("Test string.  Test string.\n", &lz4_profile);
   std::string bytes = event.to_string();
 
   SasTest::Event expected;
@@ -115,9 +119,8 @@ void test_hello_world_lz4()
 
 void test_dictionary_lz4()
 {
-  SAS::Profile profile("Test string.", SAS::Profile::Algorithm::LZ4);
   SAS::Event event(1, 2, 3);
-  event.add_compressed_param("Test string.  Test string.\n", &profile);
+  event.add_compressed_param("Test string.  Test string.\n", &lz4_dict_profile);
   std::string bytes = event.to_string();
 
   SasTest::Event expected;


### PR DESCRIPTION
Hi SAS team,

This is the LZ4 dictionary speed improvement PR I mentioned in https://github.com/Metaswitch/sas-client/pull/65.

Essentially:

- we saw that loading LZ4 dictionaries had noticeable CPU impact in Clearwater (about 3% of CPU), so we wanted to preserve a LZ4 stream with dictionaries pre-loaded
- just copying the LZ4_stream_t didn't help - it includes a large table which is mostly empty but is tedious to copy
- instead we're tracking which entries in the hash table are filled in (relatively few of the 4,096 entries - ~100 for the standard SIP dictionary) and just copying those pieces of the original hash table

This gives about a 1% perf improvement to Clearwater.

The UTs test that compression gives the same sequence of bytes, and I'm doing a live test to make sure that SAS displays the data correctly.

This isn't urgent, as it's not blocking us - we're working off the `clearwater2` branch and I've merged this there.