### PR TITLE
Rework our use of LZ4 to let us correctly compress data >4096 bytes

### DIFF
--- a/source/sas_compress.cpp
+++ b/source/sas_compress.cpp
@@ -80,9 +80,6 @@ public:
   static SAS::Compressor* get();
 
 private:
-  // The maximum size of input we can process in one go.
-  static const int MAX_INPUT_SIZE = 4096;
-
   // The default acceleration (1) is sufficient for us and gives best
   // compression.
   static const int ACCELERATION = 1;
@@ -93,7 +90,10 @@ private:
   static pthread_key_t _key;
 
   LZ4_stream_t* _stream;
-  char _buffer[LZ4_COMPRESSBOUND(MAX_INPUT_SIZE)];
+
+  int _buffer_len;
+  char* _buffer;
+
 };
 
 pthread_once_t ZlibCompressor::_once = PTHREAD_ONCE_INIT;
@@ -232,12 +232,14 @@ std::string ZlibCompressor::compress(const std::string& s, std::string dictionar
 }
 
 /// Compressor constructor.  Initializes the LZ4 compressor.
-LZ4Compressor::LZ4Compressor()
+LZ4Compressor::LZ4Compressor():
+  _buffer_len(4096)
 {
+  _buffer = (char*)malloc(_buffer_len);
   _stream = LZ4_createStream();
   if (_stream == NULL)
   {
-    SAS_LOG_WARNING("Failed to initialize LZ$ SAS parameter compressor");
+    SAS_LOG_WARNING("Failed to initialize LZ4 SAS parameter compressor");
   }
 }
 
@@ -252,23 +254,39 @@ LZ4Compressor::~LZ4Compressor()
 /// Compresses the specified string using the dictionary from the profile (if non-empty).
 std::string LZ4Compressor::compress(const std::string& s, std::string dictionary)
 {
-  if (!dictionary.empty())
-  {
-    LZ4_loadDict(_stream, dictionary.c_str(), dictionary.length());
-  }
-
   // Spin round, compressing up to a buffer's worth of input and appending it to the string.
   std::string compressed;
-  for (unsigned int s_pos = 0; s_pos < s.length(); s_pos += MAX_INPUT_SIZE)
+  bool success = false;
+  while (!success)
   {
-    // Because we've allocated a big enough buffer, it's not possible for this call to fail.
-    int buffer_len = LZ4_compress_fast_continue(_stream,
-                                                &s.c_str()[s_pos],
-                                                _buffer,
-                                                (s.length() - s_pos > MAX_INPUT_SIZE) ? MAX_INPUT_SIZE : s.length() - s_pos,
-                                                sizeof(_buffer),
-                                                ACCELERATION);
-    compressed += std::string(_buffer, buffer_len);
+    // Clear the stream after the last compression attempt.
+    LZ4_resetStream(_stream);
+
+    if (!dictionary.empty())
+    {
+      LZ4_loadDict(_stream, dictionary.c_str(), dictionary.length());
+    }
+
+    // Attempt to compress this data using the current buffer.
+    int compressed_len = LZ4_compress_fast_continue(_stream,
+                                                    s.c_str(),
+                                                    _buffer,
+                                                    s.length(),
+                                                    _buffer_len,
+                                                    ACCELERATION);
+
+    if (compressed_len <= 0)
+    {
+      // Compression failed - retry with a bigger buffer. We permanently
+      // enlarge this buffer so we aren't redoing this on every compression.
+      _buffer_len *= 2;
+      _buffer = (char*)realloc((void*)_buffer, _buffer_len);
+    }
+    else
+    {
+      compressed = std::string(_buffer, compressed_len);
+      success = true;
+    }
   }
 
   // Reset the compressor before we return.

--- a/source/sas_compress.cpp
+++ b/source/sas_compress.cpp
@@ -254,7 +254,8 @@ LZ4Compressor::~LZ4Compressor()
 /// Compresses the specified string using the dictionary from the profile (if non-empty).
 std::string LZ4Compressor::compress(const std::string& s, std::string dictionary)
 {
-  // Spin round, compressing up to a buffer's worth of input and appending it to the string.
+  // Attempt to compress the data, allocating a bigger buffer if compression
+  // fails.
   std::string compressed;
   bool success = false;
   while (!success)
@@ -277,7 +278,9 @@ std::string LZ4Compressor::compress(const std::string& s, std::string dictionary
 
     if (compressed_len <= 0)
     {
-      // Compression failed - retry with a bigger buffer. We permanently
+      // Compression failed - retry with a bigger buffer. Buffer size is the
+      // only reason it can fail (the LZ4 documentation says this function is
+      // guaranteed to succeed if the buffer is large enough). We permanently
       // enlarge this buffer so we aren't redoing this on every compression.
       _buffer_len *= 2;
       _buffer = (char*)realloc((void*)_buffer, _buffer_len);

--- a/source/ut/main_compress.cpp
+++ b/source/ut/main_compress.cpp
@@ -36,6 +36,7 @@
 
 #include "sas.h"
 #include "sastestutil.h"
+#include "lz4.h"
 
 //
 // Compression tests.
@@ -91,7 +92,7 @@ void test_dictionary()
 
 void test_hello_world_lz4()
 {
-  SAS::Profile profile(SAS::Profile::CompressionType::LZ4);
+  SAS::Profile profile(SAS::Profile::Algorithm::LZ4);
   SAS::Event event(1, 2, 3);
   event.add_compressed_param("Test string.  Test string.\n", &profile);
   std::string bytes = event.to_string();
@@ -115,7 +116,7 @@ void test_hello_world_lz4()
 
 void test_dictionary_lz4()
 {
-  SAS::Profile profile("Test string.", SAS::Profile::CompressionType::LZ4);
+  SAS::Profile profile("Test string.", SAS::Profile::Algorithm::LZ4);
   SAS::Event event(1, 2, 3);
   event.add_compressed_param("Test string.  Test string.\n", &profile);
   std::string bytes = event.to_string();
@@ -156,6 +157,33 @@ void test_empty()
   ASSERT_PRINT_BYTES(expected.var_params.size() == 1, bytes);
   ASSERT_PRINT_BYTES(expected.var_params[0] == empty_compressed, expected.var_params[0]);
 }
+
+// Test that we can compress data larger than 4096 bytes (MAX_INPUT_SIZE).
+void test_large_data()
+{
+  std::string lorem_ipsum = "Lorem ipsum dolor sit amet, soluta accusamus ei vix, quo an quas quidam scribentur, cu illud atqui mea. No mel adipisci repudiandae. Congue doctus cu vix, dolorum accusata id ius, ad dicat recusabo voluptatum his. Nam ludus choro ut, quo justo accommodare ea. Cu odio civibus dolores duo, et eos cibo reprimique, simul quaestio signiferumque ei pri.  Impedit consetetur te vel. Altera pericula ut his, ut cum offendit prodesset referrentur. Falli blandit te vel, sed te assum consectetuer vituperatoribus. Qui odio nobis labores ei. Eu iudico appareat eum, in sed causae definitionem, vocent tritani volutpat est eu.  Te vis atqui nominavi voluptatum. Quem alienum rationibus ad eum. Ignota laboramus honestatis ad quo. Vel eu virtute veritus, et brute euripidis ius. Tollit consequat scriptorem ad eam, in vix vituperata honestatis, no vitae recusabo sea.  Congue graeci laoreet et eam, quo ex modus suscipit contentiones, oratio accusamus pri et. Cu mea legendos molestiae prodesset. Ius ubique dolores conclusionemque at. An vel malis consequat. Mel an suas voluptua.  Nec te aliquam mandamus. Eum ut aliquam albucius, ad vis sonet intellegebat, no pro detracto fabellas. Vocent fuisset deleniti te quo, audiam contentiones mei ne. Ea tempor invenire quaerendum est, eu possim instructior eum. Ut aliquam evertitur tincidunt duo, impetus nostrud nam ei, eos affert oporteat persequeris in. Ne justo integre omittantur vel.  Per epicuri fastidii at, usu causae delicatissimi id. Ne ius consul repudiare. Dicat appetere ius eu, odio nobis oportere cu est. Ea natum numquam per, molestiae deseruisse vix ex, denique singulis has no. Ut novum adipiscing duo, nec cu ornatus appareat.  Ei placerat verterem tractatos eos. Cu doctus civibus has, eam volumus splendide at. Erant insolens invenire eu nec, augue scripta est ne. Wisi partem has in, civibus albucius pro ea, his stet postea no. Postea aliquip vituperata sed no, eos eu erat repudiare. Cu invenire salutatus deterruisset vis, sea ei nulla impetus, ea alii noster vivendo ius.  Et vel lorem graecis iudicabit. Ei mea utamur dolorem, tantas impedit vivendum in cum. Quis fuisset moderatius sit eu, vide meis assueverit sit te, quo errem impetus repudiandae te. Mel agam quas graecis ea.  Duo doming mollis latine et. Putant equidem inimicus mea et, te purto lorem vix, eum choro clita accusamus at. Eros alienum insolens ex eum, vitae equidem iudicabit te eam. Eam tale duis in. His no illud antiopam, erat sale te vix, agam impedit quo ei.  Ut mei albucius referrentur. Ea mel solum accusam, quodsi everti vulputate te mei. Tota putent nemore eam te, saepe fastidii ea cum. Legimus reprimique vel an, at qui detracto definiebas sadipscing, ut quod nostrud sadipscing nec. Vel id vidit fierent, ex sed tale platonem. Vel eu deleniti perfecto dissentiet, ut mei quodsi detracto, mea id novum suavitate. Ne viris postea dictas sed, erat iisque necessitatibus in has.  Mel ei iisque meliore, ne wisi tamquam est. At appareat scriptorem mea, inermis perpetua ne ius, id vitae eligendi ius. Soleat prodesset no vis, hinc munere appellantur eum te. Tale laoreet principes his an, instructior complectitur voluptatibus vel eu. Expetenda efficiendi per an. Essent expetendis quo ut, his sapientem ocurreret ei.  Per graece animal iudicabit et. Pri debet vituperata ne. Porro senserit sed ne, at has sint ocurreret. Vis populo essent expetenda an, graece aliquando ne usu, his ei noster omnium habemus.  Ex ius corrumpit expetendis. Ne his nullam evertitur eloquentiam. Ad vero eruditi cum, malis maiestatis et mei. Vim dicit deserunt definitionem ad, facete malorum molestiae in vim, cum te libris referrentur efficiantur.  No tation animal omnesque sea. Usu illud petentium in, blandit torquatos mnesarchum his at, eum an audire blandit. Mel illum ponderum prodesset an, qui ea summo postulant gubergren, est graeci ullamcorper te. Prima equidem deseruisse vim in, altera iuvaret nec no, ea putant nusquam corrumpit per. Liber scriptorem nam cu, mea quis corpora ea, sea vivendum indoctum forensibus te. Vix alia sapientem et, pri an esse mucius.  Movet vocent nostrum ex quo. His ne civibus ponderum quaestio, et habeo tation gubergren his. In modo everti qui. Probatus atomorum ne has, duo utinam mandamus voluptatibus eu, id option pertinax assueverit has.  Mei ad solet iudicabit. Mea ei minim harum iusto, eu nam affert dicunt philosophia. Homero cetero no quo, eum ad qualisque posidonium. Nec falli regione nonumes no, eu vim illud nominati. Facete nonumes eu mei, per ex labores expetenda. Eu harum epicuri atomorum sit, dicat latine inermis et mei.  Dolorem periculis efficiantur vim id. Ne omnis impetus ornatus nec. Nec in fuisset interesset, an eam tation legere. Ne mei dicit expetenda. Et mel affert prompta, zril altera bonorum vel an, ullum nonumy vituperata et eum.  At eum singulis accommodare, ius in sumo quot. Est ea harum patrioque comprehensam. Eros fierent qui an. Quo in mazim perpetua deterruisset, doming postulant constituto ex has, utinam consectetuer nam ex. Luptatum atomorum nec ex, lorem splendide repudiandae ei eos.  Fugit molestie eum an, odio eripuit mea id, sed ea choro nominati. Docendi evertitur eum id. Ei alii facete hendrerit mei, at quot graeco integre nam, in qui soluta contentiones. An eius suscipiantur per, nam in quaeque percipit, odio intellegam eum id. Zril accusam cu pro, cu mei sint nibh corpora.  Vis at ornatus nonumes sensibus, adipisci scribentur sit ut, quis molestie vim ei. Vel labores appetere repudiandae ea. Te discere omittam qui, regione omnesque sapientem his ne. Ut sea errem nostro labores.";
+
+  SAS::Profile profile(SAS::Profile::Algorithm::LZ4);
+  SAS::Event event(1, 2, 3);
+  event.add_compressed_param(lorem_ipsum, &profile);
+  std::string bytes = event.to_string();
+
+  SasTest::Event expected;
+  expected.parse(bytes);
+
+  // Attempt to decompress the compressed var param.
+  char decompressed_data[8192] = {0};
+  int rc = LZ4_decompress_fast(expected.var_params[0].data(), decompressed_data, lorem_ipsum.size());
+
+  // LZ4_decompress_fast returns the number of bytes if successful, or a negative number if unsuccessful.
+  ASSERT(rc > 0);
+  std::string decompressed_data_str = decompressed_data;
+
+  // The decompressed data should be equal to the original data.
+  ASSERT(lorem_ipsum == decompressed_data_str);
+}
+
+
 } // namespace CompressionTest
 
 int main(int argc, char *argv[])
@@ -165,6 +193,7 @@ int main(int argc, char *argv[])
   RUN_TEST(CompressionTest::test_hello_world_lz4);
   RUN_TEST(CompressionTest::test_dictionary_lz4);
   RUN_TEST(CompressionTest::test_empty);
+  RUN_TEST(CompressionTest::test_large_data);
 
   if (failures == 0)
   {


### PR DESCRIPTION
Hi SAS team,

See #68 for the background here.

It was a little tricky to backport this from the branch Clearwater uses, because we have the LZ4 enhancements from #65 and #66 merged and you don't. Any chance of getting those reviewed (or agreeing that they don't need review) so that we can un-diverge?

Thanks!