### PR TITLE
Remove reference to submodule that is no longer used

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "modules/lz4"]
-	path = modules/lz4
-	url = https://github.com/Cyan4973/lz4.git


### PR DESCRIPTION
In #65 we stopped inlcuding LZ4 as a submodule, but we left the reference for it hanging around in .gitmodules

This removes that old reference