### PR TITLE
[Reviewer: Alex] Incorrect max buffer check

### DIFF
--- a/source/sas_compress.cpp
+++ b/source/sas_compress.cpp
@@ -317,13 +317,15 @@ std::string LZ4Compressor::compress(const std::string& s, const SAS::Profile* pr
       // only reason it can fail (the LZ4 documentation says this function is
       // guaranteed to succeed if the buffer is large enough). We permanently
       // enlarge this buffer so we aren't redoing this on every compression.
-      _buffer_len *= 2;
 
       if ((_buffer_len * 2) > MAX_BUFFER_SIZE)
       {
-        SAS_LOG_WARNING("Attempting to compress %ul bytes of data - won't fit into MAX_BUFFER_SIZE", s.length());
+        SAS_LOG_WARNING("Attempting to compress %ul bytes of data - won't fit into %ul bytes",
+                        s.length(), _buffer_len);
         break;
       }
+
+      _buffer_len *= 2;
 
       _buffer = (char*)realloc((void*)_buffer, _buffer_len);
     }

--- a/source/sas_compress.cpp
+++ b/source/sas_compress.cpp
@@ -322,8 +322,8 @@ std::string LZ4Compressor::compress(const std::string& s, const SAS::Profile* pr
 
       if (new_buffer_length > MAX_BUFFER_SIZE)
       {
-        SAS_LOG_WARNING("Attempting to compress %ul bytes of data - won't fit "
-                        "into %ul bytes, proposed new buffer of %ul bytes "
+        SAS_LOG_WARNING("Attempting to compress %lu bytes of data - won't fit "
+                        "into %lu bytes, proposed new buffer of %lu bytes "
                         "exceeds maximum of %lu bytes",
                         s.length(), _buffer_len, new_buffer_length,
                         MAX_BUFFER_SIZE);

--- a/source/sas_compress.cpp
+++ b/source/sas_compress.cpp
@@ -318,14 +318,19 @@ std::string LZ4Compressor::compress(const std::string& s, const SAS::Profile* pr
       // guaranteed to succeed if the buffer is large enough). We permanently
       // enlarge this buffer so we aren't redoing this on every compression.
 
-      if ((_buffer_len * 2) > MAX_BUFFER_SIZE)
+      int new_buffer_length = _buffer_len * 2;
+
+      if (new_buffer_length > MAX_BUFFER_SIZE)
       {
-        SAS_LOG_WARNING("Attempting to compress %ul bytes of data - won't fit into %ul bytes",
-                        s.length(), _buffer_len);
+        SAS_LOG_WARNING("Attempting to compress %ul bytes of data - won't fit "
+                        "into %ul bytes, proposed new buffer of %ul bytes "
+                        "exceeds maximum of %lu bytes",
+                        s.length(), _buffer_len, new_buffer_length,
+                        MAX_BUFFER_SIZE);
         break;
       }
 
-      _buffer_len *= 2;
+      _buffer_len = new_buffer_length;
 
       _buffer = (char*)realloc((void*)_buffer, _buffer_len);
     }


### PR DESCRIPTION
Alex,

I noticed this while code reading how LZ4 compression worked.

We are incorrectly checking whether the buffer for the compressed data is too big.

We are checking whether `2 * the new buffer size` is more than the `MAX_BUFFER` size, rather than checking whether `the new buffer size` is large than `MAX_BUFFER` size.

This means our effective maximum buffer size is half what it's currently configured as. If that's what we want (which I doubt it) we should half the MAX_BUFFER constant.

I've also tweaked the logging to make it accurate - we say that the buffer won't fit in maximum buffer size, however this isn't actually accurate - what we know is that it won't fit into the current buffer length.

(I think the maximum buffer size is a multiple of two of our starting buffer size, so this will actually end up the same (as new buffer size == MAX_BUFFER_SIZE), but worth correcting anyway, and it's nicer to log the actual values, rather than requiring the code to be looked at when looking at the error.)

I've run `make test` which still passes, but I haven't actually tried to hit this condition.