### PR TITLE
[Reviewer: Alex] Increase maximum queue size to 100,000

### DIFF
--- a/source/sas.cpp
+++ b/source/sas.cpp
@@ -97,7 +97,7 @@ private:
   static const int SEND_TIMEOUT = 5;
 
   /// Maximum depth of SAS message queue.
-  static const int MAX_MSG_QUEUE = 1000;
+  static const int MAX_MSG_QUEUE = 100000;
 };
 
 int SAS::init(std::string system_name,


### PR DESCRIPTION
As discussed at length, we believe that inconsistency in scheduling the SAS transport thread, we need a larger thread in order to prevent SAS messages being dropped at rated load on Clearwater.