### PR TITLE
Free up a buffer allocated in the LZ4Compressor

### DIFF
--- a/source/sas_compress.cpp
+++ b/source/sas_compress.cpp
@@ -264,6 +264,9 @@ LZ4Compressor::~LZ4Compressor()
     LZ4_freeStream(saved_stream_iterator->second.first);
     free(saved_stream_iterator->second.second);
   }
+
+  // Free the buffer.
+  free(_buffer); _buffer = NULL; _buffer_len = 0;
 }
 
 /// Compresses the specified string using the dictionary from the profile (if non-empty).


### PR DESCRIPTION
This PR fixes up the SAS client to delete the buffer that the `LZ4Compressor` allocates. This was spotted when running valgrind tests in another project. 

Tested as follows:

* `make test` passes. 
* The valgrind tests in the other project no longer report a memory leak.